### PR TITLE
fix: If Attribute error

### DIFF
--- a/Assets/InspectorUtils/Script/Utils/Extensions.cs
+++ b/Assets/InspectorUtils/Script/Utils/Extensions.cs
@@ -24,30 +24,99 @@ namespace IUtil.Utils
 			return fieldInfo.GetValue(targetObject) as System.Array;
 		}
 
-		public static bool GetBoolean(this SerializedProperty property, string attr, string fieldName)
-		{
-			object targetObject = property.serializedObject.targetObject;
-			FieldInfo fieldInfo = targetObject.GetType().GetField(
-				fieldName,
-				BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance
-			);
+        public static bool GetBoolean(this SerializedProperty property, string attr, string fieldName)
+        {
+            object parentObject = GetTargetObjectWithProperty(property);
 
-			if (fieldInfo == null)
-			{
-				IUtilDebug.NoFieldError(attr, fieldName);
-				return false;
-			}
+            if (parentObject == null)
+            {
+                IUtilDebug.NoFieldError(attr, fieldName + "'s parent");
+                return false;
+            }
 
-			if (fieldInfo.FieldType != typeof(bool))
-			{
-				IUtilDebug.TypeError(attr, fieldInfo.FieldType.ToString());
-				return false;
-			}
+            var fieldInfo = parentObject.GetType().GetField(
+                fieldName,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance
+            );
 
-			return Convert.ToBoolean(fieldInfo.GetValue(targetObject));
-		}
+            if (fieldInfo == null)
+            {
+                IUtilDebug.NoFieldError(attr, fieldName);
+                return false;
+            }
 
-		public static string GetIconName(this FolderIconType type)
+            if (fieldInfo.FieldType != typeof(bool))
+            {
+                IUtilDebug.TypeError(attr, fieldInfo.FieldType.ToString());
+                return false;
+            }
+
+            return (bool)fieldInfo.GetValue(parentObject);
+        }
+
+        /// <summary>
+        /// Find targetObject that contains serializedProperty.
+        /// </summary>
+        public static object GetTargetObjectWithProperty(SerializedProperty prop)
+        {
+            string path = prop.propertyPath.Replace(".Array.data[", "[");
+            object obj = prop.serializedObject.targetObject;
+            string[] elements = path.Split('.')[..^1];
+
+            // follow paths to track property in same object
+            foreach (var element in elements)
+            {
+                if (element.Contains("["))
+                {
+                    var elementName = element.Substring(0, element.IndexOf("["));
+                    var index = Convert.ToInt32(element.Substring(element.IndexOf("[")).Replace("[", "").Replace("]", ""));
+                    obj = GetFieldValue(obj, elementName, index);
+                }
+                else
+                {
+                    obj = GetFieldValue(obj, element);
+                }
+
+                if (obj == null)
+                    return null;
+            }
+
+            return obj;
+        }
+
+        private static object GetFieldValue(object source, string name)
+        {
+            if (source == null)
+                return null;
+
+            var type = source.GetType();
+            var field = type.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+            if (field == null)
+            {
+                return null;
+            }
+
+            return field.GetValue(source);
+        }
+
+        private static object GetFieldValue(object source, string name, int index)
+        {
+            var enumerable = GetFieldValue(source, name) as System.Collections.IEnumerable;
+            if (enumerable == null)
+                return null;
+
+            var enumerator = enumerable.GetEnumerator();
+
+            for (int i = 0; i <= index; i++)
+            {
+                if (!enumerator.MoveNext())
+                    return null;
+            }
+
+            return enumerator.Current;
+        }
+
+        public static string GetIconName(this FolderIconType type)
 		{
 			switch (type)
 			{

--- a/Assets/InspectorUtils/Script/_Demo/DemoScript_Class.cs
+++ b/Assets/InspectorUtils/Script/_Demo/DemoScript_Class.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace IUtil._Demo
+{
+	[System.Serializable]
+	public class NestedClass
+	{
+		public bool IsShow;
+		[ShowIf(nameof(IsShow))] public string showString;
+	}
+
+    public class DemoScript_Class : MonoBehaviour
+	{
+		[SerializeField]
+		private NestedClass nestedClass = new();
+
+
+	}
+}

--- a/Assets/InspectorUtils/Script/_Demo/DemoScript_Class.cs.meta
+++ b/Assets/InspectorUtils/Script/_Demo/DemoScript_Class.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 41a59b0dda9bdee458db793fb384db9c

--- a/Assets/InspectorUtils/Script/_Demo/DemoScript_If.cs
+++ b/Assets/InspectorUtils/Script/_Demo/DemoScript_If.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using System.Collections.Generic;
+using System;
 
 namespace IUtil._Demo
 {
@@ -14,7 +16,7 @@ namespace IUtil._Demo
 
 		public bool isShow;
 		[ShowIf(nameof(isShow))]
-		public float showValue;
+		public List<float> showValue;
 
 	}
 }

--- a/Assets/InspectorUtils/_Demo/Scene/DemoScene.unity
+++ b/Assets/InspectorUtils/_Demo/Scene/DemoScene.unity
@@ -128,6 +128,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 158307654}
+  - component: {fileID: 158307655}
+  - component: {fileID: 158307656}
   m_Layer: 0
   m_Name: GameObject
   m_TagString: Untagged
@@ -150,6 +152,41 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &158307655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 158307653}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41a59b0dda9bdee458db793fb384db9c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nestedClass:
+    IsShow: 0
+    showString: 
+--- !u!114 &158307656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 158307653}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e376d389a6452a4c9d15d5dbc9941a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isReadonly: 0
+  readonlyValue: 0
+  isHide: 0
+  hideValue: 0
+  isShow: 0
+  showValue:
+  - 0
+  - 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
- work well in nested classes

```cs
	[System.Serializable]
	public class NestedClass
	{
		public bool IsShow;
		[ShowIf(nameof(IsShow))] public string showString;
	}

        public class DemoScript_Class : MonoBehaviour
	{
		[SerializeField]
		private List<NestedClass> nestedClasses = new();
	}
```

The code now works correctly. However, the [If] attribute must be applied to a field that exists within the same class instance as the boolean condition.

resolves: #8 